### PR TITLE
Fix crash in example

### DIFF
--- a/CircleMenuLib/CircleMenu.swift
+++ b/CircleMenuLib/CircleMenu.swift
@@ -376,7 +376,7 @@ public class CircleMenu: UIButton {
             $0.toValue         = (0)
             $0.fromValue       = (Float(-180).degrees)
             $0.damping         = 10
-            $0.initialVelocity = 0
+//            $0.initialVelocity = 0
             $0.beginTime = CACurrentMediaTime() + delay
         }
         let fade = Init(CABasicAnimation(keyPath: "opacity")) {


### PR DESCRIPTION
For some reason got crash on iPhone 6 plus (8.3)
comment out initialVelocity setter fixes this issue. Of course, it's not a proper solution, just want to point to this crash.

`CircleMenu[10725:1299086] *** Terminating app due to uncaught exception 'NSInvalidArgumentException', reason: '-[CASpringAnimation setInitialVelocity:]: unrecognized selector sent to instance 0x174035720'`

But I not understand, why it's not available..
