### PR TITLE
remove platform when button is tapped again to close menu

### DIFF
--- a/CircleMenuLib/CircleMenu.swift
+++ b/CircleMenuLib/CircleMenu.swift
@@ -350,6 +350,10 @@ open class CircleMenu: UIButton {
     }
     if isShow == false { // hide buttons and remove
       self.buttons = nil
+
+      DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + duration) {
+        if self.platform?.superview != nil { self.platform?.removeFromSuperview() }
+      }
     }
   }
   


### PR DESCRIPTION
When tapping the CircleButton a second time the transparent platform view isn't removed which causes buttons near the CircleButton to not be clickable.  This pull request removes the platform view after button animations have completed for that case.