### PR TITLE
Adding open menu delegate, fixed close menu delegate

### DIFF
--- a/CircleMenu.xcodeproj/project.pbxproj
+++ b/CircleMenu.xcodeproj/project.pbxproj
@@ -26,6 +26,7 @@
 		84F248BE1C58E65F008F12C1 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 84F248BD1C58E65F008F12C1 /* Assets.xcassets */; };
 		84F248C11C58E65F008F12C1 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 84F248BF1C58E65F008F12C1 /* LaunchScreen.storyboard */; };
 		84F248CC1C58E65F008F12C1 /* CircleMenuTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84F248CB1C58E65F008F12C1 /* CircleMenuTests.swift */; };
+		F5B354021E930DF100F65BBA /* CircleMenu.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8403F5791CFF2C2E007D0BD1 /* CircleMenu.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -98,6 +99,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				F5B354021E930DF100F65BBA /* CircleMenu.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -273,6 +275,7 @@
 					};
 					84F248C61C58E65F008F12C1 = {
 						CreatedOnToolsVersion = 7.2;
+						LastSwiftMigration = 0830;
 						TestTargetID = 84F248B21C58E65F008F12C1;
 					};
 				};
@@ -585,7 +588,8 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.ramotion.CircleMenuTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/CircleMenu.app/CircleMenu";
+				SWIFT_VERSION = 3.0;
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/CircleMenuDemo.app/CircleMenuDemo";
 			};
 			name = Debug;
 		};
@@ -597,7 +601,8 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.ramotion.CircleMenuTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/CircleMenu.app/CircleMenu";
+				SWIFT_VERSION = 3.0;
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/CircleMenuDemo.app/CircleMenuDemo";
 			};
 			name = Release;
 		};

--- a/CircleMenuLib/CircleMenu.swift
+++ b/CircleMenuLib/CircleMenu.swift
@@ -36,37 +36,37 @@ func Init<Type>(_ value: Type, block: (_ object: Type) -> Void) -> Type {
  *  CircleMenuDelegate
  */
 @objc public protocol CircleMenuDelegate {
-  
+
   /**
    Tells the delegate the circle menu is about to draw a button for a particular index.
-   
+
    - parameter circleMenu: The circle menu object informing the delegate of this impending event.
    - parameter button:     A circle menu button object that circle menu is going to use when drawing the row. Don't change button.tag
    - parameter atIndex:    An button index.
    */
   @objc optional func circleMenu(_ circleMenu: CircleMenu, willDisplay button: UIButton, atIndex: Int)
-  
+
   /**
    Tells the delegate that a specified index is about to be selected.
-   
+
    - parameter circleMenu: A circle menu object informing the delegate about the impending selection.
    - parameter button:     A selected circle menu button. Don't change button.tag
    - parameter atIndex:    Selected button index
    */
   @objc optional func circleMenu(_ circleMenu: CircleMenu, buttonWillSelected button: UIButton, atIndex: Int)
-  
+
   /**
    Tells the delegate that the specified index is now selected.
-   
+
    - parameter circleMenu: A circle menu object informing the delegate about the new index selection.
    - parameter button:     A selected circle menu button. Don't change button.tag
    - parameter atIndex:    Selected button index
    */
   @objc optional func circleMenu(_ circleMenu: CircleMenu, buttonDidSelected button: UIButton, atIndex: Int)
-  
+
   /**
    Tells the delegate that the menu was collapsed - the cancel action.
-   
+
    - parameter circleMenu: A circle menu object informing the delegate about the new index selection.
    */
   @objc optional func menuCollapsed(_ circleMenu: CircleMenu)
@@ -76,9 +76,9 @@ func Init<Type>(_ value: Type, block: (_ object: Type) -> Void) -> Type {
 
 /// A Button object with pop ups buttons
 open class CircleMenu: UIButton {
-  
+
   // MARK: properties
-  
+
   /// Buttons count
   @IBInspectable open var buttonsCount: Int = 3
   /// Circle animation duration
@@ -87,26 +87,26 @@ open class CircleMenu: UIButton {
   @IBInspectable open var distance: Float   = 100
   /// Delay between show buttons
   @IBInspectable open var showDelay: Double = 0
-  
+
   /// The object that acts as the delegate of the circle menu.
   @IBOutlet weak open var delegate: AnyObject? //CircleMenuDelegate?
-  
+
   var buttons: [UIButton]?
   weak var platform: UIView?
-  
+
   fileprivate var customNormalIconView: UIImageView?
   fileprivate var customSelectedIconView: UIImageView?
-  
+
   /**
    Initializes and returns a circle menu object.
-   
+
    - parameter frame:        A rectangle specifying the initial location and size of the circle menu in its superview’s coordinates.
    - parameter normalIcon:   The image to use for the specified normal state.
    - parameter selectedIcon: The image to use for the specified selected state.
    - parameter buttonsCount: The number of buttons.
    - parameter duration:     The duration, in seconds, of the animation.
    - parameter distance:     Distance between center button and sub buttons.
-   
+
    - returns: A newly created circle menu.
    */
   public init(frame: CGRect,
@@ -116,47 +116,47 @@ open class CircleMenu: UIButton {
               duration: Double = 2,
               distance: Float = 100) {
     super.init(frame: frame)
-    
+
     if let icon = normalIcon {
       setImage(UIImage(named: icon), for: UIControlState())
     }
-    
+
     if let icon = selectedIcon {
       setImage(UIImage(named: icon), for: .selected)
     }
-    
+
     self.buttonsCount = buttonsCount
     self.duration     = duration
     self.distance     = distance
-    
+
     commonInit()
   }
-  
+
   required public init?(coder aDecoder: NSCoder) {
     super.init(coder: aDecoder)
-    
+
     commonInit()
   }
-  
+
   fileprivate func commonInit() {
     addActions()
-    
+
     customNormalIconView = addCustomImageView(state: UIControlState())
-    
+
     customSelectedIconView = addCustomImageView(state: .selected)
     if customSelectedIconView != nil {
       customSelectedIconView?.alpha = 0
     }
     setImage(UIImage(), for: UIControlState())
     setImage(UIImage(), for: .selected)
-    
+
   }
-  
+
   // MARK: methods
-  
+
   /**
    Hide button
-   
+
    - parameter duration:  The duration, in seconds, of the animation.
    - parameter hideDelay: The time to delay, in seconds.
    */
@@ -164,13 +164,13 @@ open class CircleMenu: UIButton {
     if buttons == nil {
       return
     }
-    
+
     buttonsAnimationIsShow(isShow: false, duration: duration, hideDelay: hideDelay)
-    
+
     tapBounceAnimation()
     tapRotatedAnimation(0.3, isSelected: false)
   }
-  
+
   /**
    Check is sub buttons showed
    */
@@ -178,7 +178,7 @@ open class CircleMenu: UIButton {
     guard let buttons = self.buttons else {
       return false
     }
-    
+
     for button in buttons {
       if button.alpha == 0 {
         return false
@@ -186,14 +186,14 @@ open class CircleMenu: UIButton {
     }
     return true
   }
-  
+
   // MARK: create
   fileprivate func createButtons(platform: UIView) -> [UIButton] {
     var buttons = [UIButton]()
-    
+
     let step: Float = 360.0 / Float(self.buttonsCount)
     for index in 0..<self.buttonsCount {
-      
+
       let angle: Float = Float(index) * step
       let distance = Float(self.bounds.size.height/2.0)
       let button = Init(CircleMenuButton(size: self.bounds.size, platform: platform, distance:distance, angle: angle)) {
@@ -205,42 +205,42 @@ open class CircleMenu: UIButton {
     }
     return buttons
   }
-  
+
   fileprivate func addCustomImageView(state: UIControlState) -> UIImageView? {
     guard let image = image(for: state) else {
       return nil
     }
-    
+
     let iconView = Init(UIImageView(image: image)) {
       $0.translatesAutoresizingMaskIntoConstraints = false
       $0.contentMode                               = .center
       $0.isUserInteractionEnabled                    = false
     }
     addSubview(iconView)
-    
+
     // added constraints
     iconView.addConstraint(NSLayoutConstraint(item: iconView, attribute: .height, relatedBy: .equal, toItem: nil,
                                               attribute: .height, multiplier: 1, constant: bounds.size.height))
-    
+
     iconView.addConstraint(NSLayoutConstraint(item: iconView, attribute: .width, relatedBy: .equal, toItem: nil,
                                               attribute: .width, multiplier: 1, constant: bounds.size.width))
-    
+
     addConstraint(NSLayoutConstraint(item: self, attribute: .centerX, relatedBy: .equal, toItem: iconView,
                                      attribute: .centerX, multiplier: 1, constant:0))
-    
+
     addConstraint(NSLayoutConstraint(item: self, attribute: .centerY, relatedBy: .equal, toItem: iconView,
                                      attribute: .centerY, multiplier: 1, constant:0))
-    
+
     return iconView
   }
-  
+
   fileprivate func createPlatform() -> UIView {
     let platform = Init(UIView(frame: .zero)) {
       $0.backgroundColor = .clear
       $0.translatesAutoresizingMaskIntoConstraints = false
     }
     superview?.insertSubview(platform, belowSubview: self)
-    
+
     // constraints
     let sizeConstraints = [NSLayoutAttribute.width, .height].map {
       NSLayoutConstraint(item: platform,
@@ -252,7 +252,7 @@ open class CircleMenu: UIButton {
                          constant: CGFloat(distance * Float(2.0)))
     }
     platform.addConstraints(sizeConstraints)
-    
+
     let centerConstraints = [NSLayoutAttribute.centerX, .centerY].map {
       NSLayoutConstraint(item: self,
                          attribute: $0,
@@ -263,17 +263,17 @@ open class CircleMenu: UIButton {
                          constant:0)
     }
     superview?.addConstraints(centerConstraints)
-    
+
     return platform
   }
-  
+
   // MARK: configure
   fileprivate func addActions() {
     self.addTarget(self, action: #selector(CircleMenu.onTap), for: UIControlEvents.touchUpInside)
   }
-  
+
   // MARK: actions
-  
+
   func onTap() {
     if buttonsIsShown() == false {
       let platform = createPlatform()
@@ -283,26 +283,26 @@ open class CircleMenu: UIButton {
     let isShow = !buttonsIsShown()
     let duration  = isShow ? 0.5 : 0.2
     buttonsAnimationIsShow(isShow: isShow, duration: duration)
-    
+
     tapBounceAnimation()
     tapRotatedAnimation(0.3, isSelected: isShow)
   }
-  
+
   func buttonHandler(_ sender: CircleMenuButton) {
     guard let platform = self.platform else { return }
 
     delegate?.circleMenu?(self, buttonWillSelected: sender, atIndex: sender.tag)
-    
+
     let circle = CircleMenuLoader(radius: CGFloat(distance),
                                   strokeWidth: bounds.size.height,
                                   platform: platform,
                                   color: sender.backgroundColor)
-    
+
     if let container = sender.container { // rotation animation
       sender.rotationAnimation(container.angleZ + 360, duration: duration)
       container.superview?.bringSubview(toFront: container)
     }
-    
+
     if let buttons = buttons {
       circle.fillAnimation(duration, startAngle: -90 + Float(360 / buttons.count) * Float(sender.tag)) { [weak self] _ in
         self?.buttons?.forEach { $0.alpha = 0 }
@@ -310,51 +310,50 @@ open class CircleMenu: UIButton {
       circle.hideAnimation(0.5, delay: duration) { [weak self] _ in
         if self?.platform?.superview != nil { self?.platform?.removeFromSuperview() }
       }
-      
+
       hideCenterButton(duration: 0.3)
       showCenterButton(duration: 0.525, delay: duration)
 
       if customNormalIconView != nil && customSelectedIconView != nil {
-        
+
         DispatchQueue.main.asyncAfter(deadline: .now() + duration, execute: {
           self.delegate?.circleMenu?(self, buttonDidSelected: sender, atIndex: sender.tag)
         })
       }
     }
   }
-  
+
   // MARK: animations
-  
+
   fileprivate func buttonsAnimationIsShow(isShow: Bool, duration: Double, hideDelay: Double = 0) {
     guard let buttons = self.buttons else {
       return
     }
-    
+
     let step: Float = 360.0 / Float(self.buttonsCount)
     for index in 0..<self.buttonsCount {
       guard case let button as CircleMenuButton = buttons[index] else { continue }
       let angle: Float = Float(index) * step
       if isShow == true {
         delegate?.circleMenu?(self, willDisplay: button, atIndex: index)
-        
+
         button.rotatedZ(angle: angle, animated: false, delay: Double(index) * showDelay)
         button.showAnimation(distance: distance, duration: duration, delay: Double(index) * showDelay)
       } else {
         button.hideAnimation(
           distance: Float(self.bounds.size.height / 2.0),
           duration: duration, delay: hideDelay)
-        self.delegate?.menuCollapsed?(self)
       }
     }
     if isShow == false { // hide buttons and remove
       self.buttons = nil
-
+      self.delegate?.menuCollapsed?(self)
       DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + duration) {
         if self.platform?.superview != nil { self.platform?.removeFromSuperview() }
       }
     }
   }
-  
+
   fileprivate func tapBounceAnimation() {
     self.transform = CGAffineTransform(scaleX: 0.9, y: 0.9)
     UIView.animate(withDuration: 0.5, delay: 0, usingSpringWithDamping: 0.3, initialSpringVelocity: 5,
@@ -364,9 +363,9 @@ open class CircleMenu: UIButton {
       },
                    completion: nil)
   }
-  
+
   fileprivate func tapRotatedAnimation(_ duration: Float, isSelected: Bool) {
-    
+
     let addAnimations: (_ view: UIImageView, _ isShow: Bool) -> () = { (view, isShow) in
       var toAngle: Float   = 180.0
       var fromAngle: Float = 0
@@ -382,7 +381,7 @@ open class CircleMenu: UIButton {
         fromOpacity = 0
         toOpacity   = 1
       }
-      
+
       let rotation = Init(CABasicAnimation(keyPath: "transform.rotation")) {
         $0.duration       = TimeInterval(duration)
         $0.toValue        = (toAngle.degrees)
@@ -403,12 +402,12 @@ open class CircleMenu: UIButton {
         $0.fromValue      = fromScale
         $0.timingFunction = CAMediaTimingFunction(name: kCAMediaTimingFunctionEaseInEaseOut)
       }
-      
+
       view.layer.add(rotation, forKey: nil)
       view.layer.add(fade, forKey: nil)
       view.layer.add(scale, forKey: nil)
     }
-    
+
     if let customNormalIconView = self.customNormalIconView {
       addAnimations(customNormalIconView, !isSelected)
     }
@@ -419,7 +418,7 @@ open class CircleMenu: UIButton {
     self.isSelected = isSelected
     self.alpha = isSelected ? 0.3 : 1
   }
-  
+
   fileprivate func hideCenterButton(duration: Double, delay: Double = 0) {
     UIView.animate( withDuration: TimeInterval(duration), delay: TimeInterval(delay),
                     options: UIViewAnimationOptions.curveEaseOut,
@@ -427,7 +426,7 @@ open class CircleMenu: UIButton {
                       self.transform = CGAffineTransform(scaleX: 0.001, y: 0.001)
       }, completion: nil)
   }
-  
+
   fileprivate func showCenterButton(duration: Float, delay: Double) {
     UIView.animate( withDuration: TimeInterval(duration), delay: TimeInterval(delay), usingSpringWithDamping: 0.78,
                     initialSpringVelocity: 0, options: UIViewAnimationOptions.curveLinear,
@@ -436,7 +435,7 @@ open class CircleMenu: UIButton {
                       self.alpha     = 1
       },
                     completion: nil)
-    
+
     let rotation = Init(CASpringAnimation(keyPath: "transform.rotation")) {
       $0.duration        = TimeInterval(1.5)
       $0.toValue         = (0)
@@ -445,7 +444,7 @@ open class CircleMenu: UIButton {
       $0.initialVelocity = 0
       $0.beginTime       = CACurrentMediaTime() + delay
     }
-    
+
     let fade = Init(CABasicAnimation(keyPath: "opacity")) {
       $0.duration            = TimeInterval(0.01)
       $0.toValue             = 0
@@ -462,10 +461,10 @@ open class CircleMenu: UIButton {
       $0.isRemovedOnCompletion = false
       $0.beginTime           = CACurrentMediaTime() + delay
     }
-    
+
     customNormalIconView?.layer.add(rotation, forKey: nil)
     customNormalIconView?.layer.add(show, forKey: nil)
-    
+
     customSelectedIconView?.layer.add(fade, forKey: nil)
   }
 }
@@ -476,14 +475,14 @@ internal extension Float {
   var radians: Float {
     return self * (Float(180) / Float(M_PI))
   }
-  
+
   var degrees: Float {
     return self  * Float(M_PI) / 180.0
   }
 }
 
 internal extension UIView {
-  
+
   var angleZ: Float {
     return atan2(Float(self.transform.b), Float(self.transform.a)).radians
   }

--- a/CircleMenuLib/CircleMenu.swift
+++ b/CircleMenuLib/CircleMenu.swift
@@ -287,7 +287,7 @@ open class CircleMenu: UIButton {
       buttons = createButtons(platform: platform)
       self.platform = platform
       DispatchQueue.main.asyncAfter(deadline: .now()) {
-        self.delegate?.menuOpened!(self)
+        self.delegate?.menuOpened?(self)
       }
     }
     let isShow = !buttonsIsShown()
@@ -358,7 +358,7 @@ open class CircleMenu: UIButton {
     if isShow == false { // hide buttons and remove
       self.buttons = nil
       DispatchQueue.main.asyncAfter(deadline: .now()) {
-          self.delegate?.menuCollapsed!(self)
+          self.delegate?.menuCollapsed?(self)
       }
       DispatchQueue.main.asyncAfter(deadline: .now() + duration) {
           if self.platform?.superview != nil { self.platform?.removeFromSuperview() }
@@ -485,11 +485,11 @@ open class CircleMenu: UIButton {
 
 internal extension Float {
   var radians: Float {
-    return self * (Float(180) / Float(M_PI))
+    return self * (Float(180) / Float.pi)
   }
 
   var degrees: Float {
-    return self  * Float(M_PI) / 180.0
+    return self  * Float.pi / 180.0
   }
 }
 

--- a/CircleMenuLib/CircleMenu.swift
+++ b/CircleMenuLib/CircleMenu.swift
@@ -65,11 +65,18 @@ func Init<Type>(_ value: Type, block: (_ object: Type) -> Void) -> Type {
   @objc optional func circleMenu(_ circleMenu: CircleMenu, buttonDidSelected button: UIButton, atIndex: Int)
 
   /**
-   Tells the delegate that the menu was collapsed - the cancel action.
+   Tells the delegate that the menu was collapsed - the cancel action. Fires immediately on button press
 
    - parameter circleMenu: A circle menu object informing the delegate about the new index selection.
    */
   @objc optional func menuCollapsed(_ circleMenu: CircleMenu)
+
+  /**
+   Tells the delegate that the menu was opened. Fires immediately on button press
+
+   - parameter circleMenu: A circle menu object informing the delegate about the new index selection.
+   */
+  @objc optional func menuOpened(_ circleMenu: CircleMenu)
 }
 
 // MARK: CircleMenu
@@ -279,6 +286,9 @@ open class CircleMenu: UIButton {
       let platform = createPlatform()
       buttons = createButtons(platform: platform)
       self.platform = platform
+      DispatchQueue.main.asyncAfter(deadline: .now()) {
+        self.delegate?.menuOpened!(self)
+      }
     }
     let isShow = !buttonsIsShown()
     let duration  = isShow ? 0.5 : 0.2
@@ -347,9 +357,11 @@ open class CircleMenu: UIButton {
     }
     if isShow == false { // hide buttons and remove
       self.buttons = nil
-      self.delegate?.menuCollapsed?(self)
-      DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + duration) {
-        if self.platform?.superview != nil { self.platform?.removeFromSuperview() }
+      DispatchQueue.main.asyncAfter(deadline: .now()) {
+          self.delegate?.menuCollapsed!(self)
+      }
+      DispatchQueue.main.asyncAfter(deadline: .now() + duration) {
+          if self.platform?.superview != nil { self.platform?.removeFromSuperview() }
       }
     }
   }

--- a/CircleMenuLib/CircleMenuLoader/CircleMenuLoader.swift
+++ b/CircleMenuLib/CircleMenuLoader/CircleMenuLoader.swift
@@ -60,7 +60,7 @@ internal class CircleMenuLoader: UIView {
       arcCenter: CGPoint(x: radius, y: radius),
       radius: CGFloat(radius) - strokeWidth / 2.0,
       startAngle: CGFloat(0),
-      endAngle:CGFloat(M_PI * 2),
+      endAngle:CGFloat.pi * 2,
       clockwise: true)
     
     let circle = Init(CAShapeLayer()) {

--- a/README.md
+++ b/README.md
@@ -90,8 +90,11 @@ optional func circleMenu(circleMenu: CircleMenu, buttonWillSelected button: Circ
 // call after animation
 optional func circleMenu(circleMenu: CircleMenu, buttonDidSelected button: CircleMenuButton, atIndex: Int)
 
-// call upon cancel of the menu
+// call upon cancel of the menu - fires immediately on button press
 optional func menuCollapsed(circleMenu: CircleMenu)
+
+// call upon opening of the menu - fires immediately on button press
+optional func menuOpened(circleMenu: CircleMenu)
 ```
 
 ## Licence

--- a/README.md
+++ b/README.md
@@ -92,8 +92,11 @@ optional func circleMenu(circleMenu: CircleMenu, buttonWillSelected button: Circ
 // call after animation
 optional func circleMenu(circleMenu: CircleMenu, buttonDidSelected button: CircleMenuButton, atIndex: Int)
 
-// call upon cancel of the menu
+// call upon cancel of the menu - fires immediately on button press
 optional func menuCollapsed(circleMenu: CircleMenu)
+
+// call upon opening of the menu - fires immediately on button press
+optional func menuOpened(circleMenu: CircleMenu)
 ```
 
 ## Licence


### PR DESCRIPTION
Added an open menu delegate that will get fired when the user select the button to open the menu.
Corrected the close menu delegate so that it is not fired for every button of the menu. It will now only fire once.
Changed both open menu and close menu delegates to fire asynchronously
Updated README
Updated for Swift 3.2 (.pi updates)