### PR TITLE
`customNormalIconView` and `customSelectedIconView` can't be nil. I'm…

### DIFF
--- a/CircleMenuLib/CircleMenu.swift
+++ b/CircleMenuLib/CircleMenu.swift
@@ -370,13 +370,10 @@ open class CircleMenu: UIButton {
         
         hideCenterButton(duration: 0.3)
         showCenterButton(duration: 0.525, delay: duration)
-        
-        if customNormalIconView != nil && customSelectedIconView != nil {
-            
-            DispatchQueue.main.asyncAfter(deadline: .now() + duration, execute: {
-                self.delegate?.circleMenu?(self, buttonDidSelected: sender, atIndex: sender.tag)
-            })
-        }
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + duration, execute: {
+            self.delegate?.circleMenu?(self, buttonDidSelected: sender, atIndex: sender.tag)
+        })
     }
 
     // MARK: animations


### PR DESCRIPTION
`customNormalIconView` and `customSelectedIconView` can't be nil. I'm using ionicons-fonts not images. I can't see the reason why I need to set any images. (7f2a3f8) It might be legacy code form wayback when the delegate methods were introduced or software engineering bureaucracy. Either way, good job Alex.k for making this project possible. Only he could just push a tiny bit further :p

See issue50 https://github.com/Ramotion/circle-menu/issues/50